### PR TITLE
Switch to Flutter colorScheme

### DIFF
--- a/lib/src/activities_page/activities.dart
+++ b/lib/src/activities_page/activities.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:refresh/src/activities_list.dart';
-import 'package:refresh/src/theme.dart';
 import 'activity_tile.dart';
 import 'draggable_sheet.dart';
 
@@ -14,20 +13,16 @@ class ActivitiesPage extends StatefulWidget {
 }
 
 class _ActivitiesPageState extends State<ActivitiesPage> {
-
   void setActState() {
     setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
-    Brightness brightness = Theme.of(context).brightness;
-    Color backgroundColor =
-        ThemeColor.getColor(ColorType.background, brightness);
-    Color textColor = ThemeColor.getColor(ColorType.text, brightness);
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
-      backgroundColor: backgroundColor,
+      backgroundColor: colorScheme.background,
       body: Stack(
         children: [
           Center(
@@ -43,7 +38,7 @@ class _ActivitiesPageState extends State<ActivitiesPage> {
                         child: IconButton(
                           icon: const Icon(Icons.arrow_back_ios),
                           iconSize: 28,
-                          color: textColor,
+                          color: colorScheme.onBackground,
                           onPressed: () {
                             Navigator.pop(context);
                           },
@@ -55,6 +50,8 @@ class _ActivitiesPageState extends State<ActivitiesPage> {
                           child: Text(
                             'Activities',
                             style: TextStyle(
+                              // Consider changing the colorScheme
+                              // 'onBackground' color to this
                               color: Color(0xFFF9F9F9),
                               fontSize: 32,
                               fontFamily: 'Montserrat',
@@ -73,8 +70,7 @@ class _ActivitiesPageState extends State<ActivitiesPage> {
                       IconButton(
                         icon: const Icon(Icons.swap_vert),
                         iconSize: 28,
-                        color: ThemeColor.getColor(
-                            ColorType.text, Brightness.dark),
+                        color: colorScheme.onBackground,
                         onPressed: () {
                           // Implement sorting logic here
                         },
@@ -102,8 +98,8 @@ class _ActivitiesPageState extends State<ActivitiesPage> {
                             width: 2), // Yellow border around the ListView
                       ),
                       child: ListView.builder(
-                        padding:
-                            EdgeInsets.only(top: 0), // Set top padding to 0
+                        padding: const EdgeInsets.only(
+                            top: 0), // Set top padding to 0
                         itemCount: usersActivities.length,
                         itemBuilder: (BuildContext context, int index) {
                           return ActivityTile(

--- a/lib/src/activities_page/activity_tile.dart
+++ b/lib/src/activities_page/activity_tile.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../theme.dart';
 
 class ActivityTile extends StatelessWidget {
   final String emoji;
@@ -13,12 +12,14 @@ class ActivityTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Container(
         height: 64, // Set the desired height
         decoration: BoxDecoration(
-          color: ThemeColor.getColor(ColorType.darkGray, Brightness.dark),
+          color: colorScheme.tertiary,
           borderRadius: BorderRadius.circular(10),
         ),
         child: Align(
@@ -52,7 +53,7 @@ class ActivityTile extends StatelessWidget {
                   child: IconButton(
                     icon: const Icon(Icons.more_horiz),
                     iconSize: 28,
-                    color: ThemeColor.getColor(ColorType.text, Brightness.dark),
+                    color: colorScheme.onBackground,
                     onPressed: () {
                       // Implement sorting logic here
                     },

--- a/lib/src/activities_page/draggable_sheet.dart
+++ b/lib/src/activities_page/draggable_sheet.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:refresh/src/theme.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'searchbar.dart';
@@ -68,6 +67,8 @@ class _DraggableSheetState extends State<DraggableSheet> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return DraggableScrollableSheet(
       controller: _scrollableController, // Pass the controller
       initialChildSize: closeSize,
@@ -79,7 +80,7 @@ class _DraggableSheetState extends State<DraggableSheet> {
           children: [
             Container(
               decoration: BoxDecoration(
-                color: ThemeColor.getColor(ColorType.darkGray, Brightness.dark),
+                color: colorScheme.secondary,
                 borderRadius: BorderRadius.circular(10.0),
                 boxShadow: [
                   BoxShadow(
@@ -118,7 +119,6 @@ class _DraggableSheetState extends State<DraggableSheet> {
                               onPressed: () {
                                 if (!usersActivities
                                     .contains(filteredIndices[index])) {
-                                      
                                   // add index to users activities
                                   usersActivities.add(filteredIndices[index]);
                                   storeUserActivities();
@@ -128,7 +128,6 @@ class _DraggableSheetState extends State<DraggableSheet> {
                                   print(
                                       "current userActivities: $usersActivities");
                                 } else {
-                                  
                                   // benign
                                   usersActivities
                                       .remove(filteredIndices[index]);

--- a/lib/src/activities_page/searchbar.dart
+++ b/lib/src/activities_page/searchbar.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../theme.dart';
 
 class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
   final VoidCallback openSheet;
@@ -17,10 +16,12 @@ class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
   @override
   Widget build(
       BuildContext context, double shrinkOffset, bool overlapsContent) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return Container(
       decoration: BoxDecoration(
         // box decoration is unnecesary if padding is switched to the container
-        color: ThemeColor.getColor(ColorType.darkGray, Brightness.dark),
+        color: colorScheme.background,
         borderRadius: BorderRadius.circular(10.0),
       ),
       child: Padding(
@@ -35,8 +36,7 @@ class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
                 width: 40,
                 height: 6,
                 decoration: BoxDecoration(
-                  color: ThemeColor.getColor(ColorType.darkElement,
-                      Brightness.dark), // Set the background color
+                  color: colorScheme.secondary, // Set the background color
                   borderRadius:
                       BorderRadius.circular(3.0), // Set the border radius
                 ),
@@ -51,8 +51,7 @@ class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
                       height: 46,
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(6),
-                        color: ThemeColor.getColor(
-                            ColorType.background, Brightness.dark),
+                        color: colorScheme.background,
                       ),
                       child: Center(
                         child: TextField(
@@ -60,8 +59,7 @@ class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
                             fontFamily: 'Montserrat',
                             fontSize: 16,
                             fontWeight: FontWeight.w500,
-                            color: ThemeColor.getColor(
-                                ColorType.text, Brightness.dark), // text color
+                            color: colorScheme.background, // text color
                           ),
                           controller: textController,
 
@@ -70,13 +68,11 @@ class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
                           },
 
                           textAlign: TextAlign.left,
-                          cursorColor: ThemeColor.getColor(ColorType.primary,
-                              Brightness.dark), // cursor color
+                          cursorColor: colorScheme.primary, // cursor color
                           decoration: InputDecoration(
                             prefixIcon: Icon(
                               Icons.search,
-                              color: ThemeColor.getColor(
-                                  ColorType.darkElement, Brightness.dark),
+                              color: colorScheme.secondary,
                               size: 24.0,
                             ),
                             counterText: "",
@@ -86,8 +82,7 @@ class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
                               fontFamily: 'Montserrat',
                               fontSize: 16,
                               fontWeight: FontWeight.w500,
-                              color: ThemeColor.getColor(ColorType.darkElement,
-                                  Brightness.dark), // hint text color
+                              color: colorScheme.secondary, // hint text color
                             ),
                             border: OutlineInputBorder(
                               borderSide: BorderSide.none,
@@ -109,9 +104,7 @@ class CustomHeaderDelegate extends SliverPersistentHeaderDelegate {
                         const EdgeInsets.only(left: 6, right: 8, bottom: 10.0),
                     child: IconButton(
                       icon: Icon(Icons.add_circle_outline,
-                          size: 36,
-                          color: ThemeColor.getColor(
-                              ColorType.primary, Brightness.dark)),
+                          size: 36, color: colorScheme.primary),
                       onPressed: () {
                         openSheet();
                       },

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -6,6 +6,7 @@ import 'main_page/refresh.dart';
 import 'activities_page/activities.dart';
 import 'settings/settings_controller.dart';
 import 'settings/settings_view.dart';
+import 'theme.dart';
 
 /// The Widget that configures your application.
 class MyApp extends StatelessWidget {
@@ -56,8 +57,8 @@ class MyApp extends StatelessWidget {
           // Define a light and dark color theme. Then, read the user's
           // preferred ThemeMode (light, dark, or system default) from the
           // SettingsController to display the correct theme.
-          theme: ThemeData(),
-          darkTheme: ThemeData.dark(),
+          theme: ThemeData.from(colorScheme: lightColorScheme),
+          darkTheme: ThemeData.from(colorScheme: darkColorScheme),
           themeMode: settingsController.themeMode,
 
           // Define a function to handle named routes in order to support

--- a/lib/src/example_activities.dart
+++ b/lib/src/example_activities.dart
@@ -1,4 +1,4 @@
-import 'package:refresh/src/types.dart';
+import 'types.dart';
 
 // TEMPORARY EXAMPLE ACTIVITIES LIST
 List<ActivityType> exampleActivities = [

--- a/lib/src/main_page/acceptance.dart
+++ b/lib/src/main_page/acceptance.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:refresh/src/theme.dart';
+
+const buttonPaddingBottom = 40.0;
+const buttonWidthFactor = 0.8;
 
 class AcceptanceButton extends StatelessWidget {
   const AcceptanceButton({super.key, required this.onPressed});
@@ -8,16 +10,14 @@ class AcceptanceButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Get the current color scheme
-    Brightness brightness = Theme.of(context).brightness;
-    Color primaryColor = ThemeColor.getColor(ColorType.primary, brightness);
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Padding(
       // 40.0 from the bottom of the screen
-      padding: const EdgeInsets.only(bottom: 40.0),
+      padding: const EdgeInsets.only(bottom: buttonPaddingBottom),
       child: FractionallySizedBox(
         // 80% of screen width
-        widthFactor: 0.8,
+        widthFactor: buttonWidthFactor,
 
         child: ElevatedButton(
           // Button action which is passed in as parameter
@@ -28,7 +28,7 @@ class AcceptanceButton extends StatelessWidget {
             padding: MaterialStateProperty.all(
               const EdgeInsets.symmetric(vertical: 20.0),
             ),
-            backgroundColor: MaterialStateProperty.all(primaryColor),
+            backgroundColor: MaterialStateProperty.all(colorScheme.primary),
             shape: MaterialStateProperty.all(
               RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(15.0),
@@ -37,9 +37,9 @@ class AcceptanceButton extends StatelessWidget {
           ),
 
           // Button text
-          child: const Text(
+          child: Text(
             "Let's run it",
-            style: TextStyle(fontSize: 24),
+            style: TextStyle(fontSize: 24, color: colorScheme.onPrimary),
           ),
         ),
       ),

--- a/lib/src/main_page/activity.dart
+++ b/lib/src/main_page/activity.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:refresh/src/theme.dart';
-import 'package:refresh/src/main_page/animated_positioned_opacity.dart';
-import 'package:refresh/src/types.dart';
+import '../main_page/animated_positioned_opacity.dart';
+import '../types.dart';
 
 // How long a swipe animation takes
 const swipeDuration = Duration(milliseconds: 250);
@@ -68,8 +67,7 @@ class ActivityWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Get the current color scheme
-    Brightness brightness = Theme.of(context).brightness;
-    Color textColor = ThemeColor.getColor(ColorType.text, brightness);
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 40.0),
@@ -89,7 +87,7 @@ class ActivityWidget extends StatelessWidget {
             style: TextStyle(
               fontSize: 36.0,
               fontWeight: FontWeight.bold,
-              color: textColor,
+              color: colorScheme.onBackground,
             ),
           ),
         ],

--- a/lib/src/main_page/refresh.dart
+++ b/lib/src/main_page/refresh.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:refresh/src/activities_page/activities.dart';
-import 'package:refresh/src/main_page/acceptance.dart';
-import 'package:refresh/src/theme.dart';
-import 'package:refresh/src/main_page/activity.dart';
-import 'package:refresh/src/types.dart';
-import 'package:refresh/src/example_activities.dart';
+import '../activities_page/activities.dart';
+import '../main_page/acceptance.dart';
+import '../main_page/activity.dart';
+import '../types.dart';
+import '../example_activities.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../activities_list.dart';
@@ -87,29 +86,25 @@ class _MainPageState extends State<MainPage> {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.clear();
   }
+
   // Callback function passed to the AcceptanceButton
   // TODO Acceptance animation when user presses "Let's run it"
   void acceptanceCallback() {}
 
-  
   @override
   Widget build(BuildContext context) {
     // Get the current color scheme
-    Brightness brightness = Theme.of(context).brightness;
-    Color backgroundColor =
-        ThemeColor.getColor(ColorType.background, brightness);
-    Color primaryColor = ThemeColor.getColor(ColorType.primary, brightness);
-    Color textColor = ThemeColor.getColor(ColorType.text, brightness);
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
-      backgroundColor: backgroundColor,
+      backgroundColor: colorScheme.background,
       floatingActionButton: Padding(
         padding:
             const EdgeInsets.only(top: iconPaddingTop, right: iconPaddingRight),
         child: Align(
           alignment: Alignment.topRight,
           child: FloatingActionButton(
-            backgroundColor: primaryColor,
+            backgroundColor: colorScheme.primary,
             onPressed: () {
               //clearSharedPrefs();
               // Navigate to the settings page. If the user leaves and returns
@@ -163,7 +158,7 @@ class _MainPageState extends State<MainPage> {
                     'How about...',
                     style: TextStyle(
                       fontSize: 30.0,
-                      color: textColor,
+                      color: colorScheme.onBackground,
                     ),
                   ),
                 ),

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -1,36 +1,29 @@
 import 'package:flutter/material.dart';
 
-enum ColorType {
-  text,
-  background,
-  primary,
-  disabledText,
-  darkElement,
-  darkGray,
-}
+// Color scheme has been changed. Here is a mapping between
+// the names of the old colors to the names of the new colors:
 
-class ThemeColor {
-  static final Map<(ColorType, Brightness), Color> _colorMap = {
-    // Dark Theme Colors
-    (ColorType.text, Brightness.dark): const Color(0xFFFFFFFF),
-    (ColorType.background, Brightness.dark): const Color(0xFF111313),
-    (ColorType.primary, Brightness.dark): const Color(0xFF50A2D2),
-    (ColorType.disabledText, Brightness.dark): const Color(0xFF616161),
-    (ColorType.darkElement, Brightness.dark): const Color(0xFF616161),
-    (ColorType.darkGray, Brightness.dark): const Color(0xFF292929),
+// text => onBackground
+// disabledText => secondary
+// darkElement => seconday
+// darkGray => tertiary
 
-    // TODO update to the light theme colors we want
-    // Light Theme Colors
-    (ColorType.text, Brightness.light): const Color(0xFF000000),
-    (ColorType.background, Brightness.light): const Color(0xFFFFFFFF),
-    (ColorType.primary, Brightness.light): const Color(0xFF0000FF),
-    (ColorType.disabledText, Brightness.light): const Color(0xFF888888),
-    (ColorType.darkElement, Brightness.light): const Color(0xFF555555),
-    (ColorType.darkGray, Brightness.light): const Color(0xFF444444),
-  };
+// Note: The actual colors haven't changed, just the names
 
-  static Color getColor(ColorType themeColor, Brightness brightness) {
-    return _colorMap[(themeColor, brightness)] ??
-        Colors.black; // Provide a default color if not found
-  }
-}
+const darkColorScheme = ColorScheme.dark(
+  background: Color(0xFF111313),
+  onBackground: Color(0xFFFFFFFF),
+  primary: Color(0xFF50A2D2),
+  onPrimary: Color(0xFFFFFFFF),
+  secondary: Color(0xFF616161),
+  tertiary: Color(0xFF292929),
+);
+
+const lightColorScheme = ColorScheme.light(
+  background: Color(0xFFFFFFFF),
+  onBackground: Color(0xFF000000),
+  primary: Color(0xFF0000FF),
+  onPrimary: Color(0xFF000000),
+  secondary: Color(0xFF616161),
+  tertiary: Color(0xFFE0E0E0),
+);


### PR DESCRIPTION
To improve the color scheme use in the app, use Flutter's built-in methods of color scheme and theme data. This will make accessing colors more simple and leave us with cleaner code. This will also make defining color schemes easier. No file except app.dart now has to import 'theme.dart'.

Remove 'package:refresh/src/' portion of import statements. It is boilerplate with benefit that is not worth the cost.